### PR TITLE
Update msprep.R

### DIFF
--- a/R/msprep.R
+++ b/R/msprep.R
@@ -222,7 +222,7 @@ msprep <- function (time, status, data, trans, start, id, keep)
     msres <- msres[ord, ]
     row.names(msres) <- 1:nrow(msres)
     if (!is.null(idlevels)) 
-        msres[, 1] <- factor(msres[, 1], 1:length(idlevels), 
+        msres[, 1] <- factor(as.integer(msres[, 1]), 1:length(idlevels), 
             labels = idlevels)
     if (!missing(keep)) {
         if (!(is.matrix(keep) | (is.data.frame(keep)))) {


### PR DESCRIPTION
The following part within the `msprep` function sometimes does not work as intended because `msres[, 1]` is numeric and `1:length(idlevels)` is integer.
It seems to occur when the vectors are very long.

```
if (!is.null(idlevels)) 
  msres[, 1] <- factor(msres[, 1], 1:length(idlevels), 
                       labels = idlevels)
```

To reproduce this issue, download a sample dataset and execute the following code.
[msrescol1.rds](https://app.box.com/s/7o3lvlie9a1pprfxtjo9fga3dz4zle7l)
[idlevels.rds](https://app.box.com/s/rsrmp0zyuzpfbvi7mdouha8boqkygo8o)

```
msrescol1 = readRDS("msrescol1.rds")
idlevels = readRDS("idlevels.rds")
resultold = factor(msrescol1, 1:length(idlevels), labels = idlevels)
resultnew = factor(as.integer(msrescol1), 1:length(idlevels), labels = idlevels)
setdiff(idlevels, resultold) # not as intended
# [1] "2175662" "3351020" "4526956" "5704306"
setdiff(idlevels, resultnew) # as intended
# character(0)
```