### PR TITLE
Correct bugs in calculation of censoring and truncation weights

### DIFF
--- a/R/create.wData.omega.R
+++ b/R/create.wData.omega.R
@@ -9,7 +9,7 @@ function(Tstart, Tstop, status, id, stratum, failcode, cens){
   ## Number of rows in dataset with weights
   Nw[sel.compet] <-  apply(outer(Tstop[sel.compet],event.times,"<"), 1, sum)+1
   data.weight <- data.frame(id=rep(id,Nw), Tstart=NA, Tstop=NA, status=rep(status,Nw),
-                            strata=rep(stratum,sum(Nw)))
+                            strata=rep(stratum,Nw))
   data.weight$Tstart <- unlist(lapply(1:n, FUN=function(x,tms,N) {
                                                if (N[x]==1) {
                                                 Tstart[x]

--- a/R/crprep.R
+++ b/R/crprep.R
@@ -1,10 +1,10 @@
 #' Function to create weighted data set for competing risks analyses
-#' 
+#'
 #' This function converts a dataset that is in short format (one subject per
 #' line) into a counting process format with time-varying weights that correct
 #' for right censored and left truncated data. With this data set, analyses
 #' based on the subdistribution hazard can be performed.
-#' 
+#'
 #' For each event type as specified via \code{trans}, individuals with a
 #' competing event remain in the risk set with weights that are determined by
 #' the product-limit forms of the time-to-censoring and time-to-entry
@@ -12,21 +12,21 @@
 #' such individuals are split into several rows. Censoring weights are always
 #' computed. Truncation weights are computed only if \code{Tstart} is
 #' specified.
-#' 
+#'
 #' If several event types are specified at once, regression analyses using the
 #' stacked format data set can be performed (see Putter et al. 2007 and Chapter
 #' 4 in Geskus 2016). The data set can also be used for a regression on the
 #' cause-specific hazard by restricting to the subset \code{subset=count==0}.
-#' 
+#'
 #' Missing values are allowed in \code{Tstop}, \code{status}, \code{Tstart},
 #' \code{strata} and \code{keep}. Rows for which \code{Tstart} or \code{Tstart}
 #' is missing are deleted.
-#' 
+#'
 #' There are two ways to supply the data. If given "by value" (option 1), the
 #' actual data vectors are used. If given "by name" (option 2), the column
 #' names are specified, which are read from the data set in \code{data}. In
 #' general, the second option is preferred.
-#' 
+#'
 #' If data are given by value, the following holds for the naming of the
 #' columns in the output data set. If \code{keep}, \code{strata} or \code{id}
 #' is a vector from a (sub)-list, e.g. obj$name2$name1, then the column name is
@@ -36,11 +36,11 @@
 #' a named matrix, the same names are used for the covariate columns in the
 #' output data set. If keep is a matrix without names, then the covariate
 #' columns are given the names "V1" until "Vk".
-#' 
+#'
 #' The current function does not allow to create a weighted data set in which
 #' the censoring and/or truncation mechanisms depend on covariates via a
 #' regression model.
-#' 
+#'
 #' @aliases crprep crprep.default
 #' @param Tstop Either 1) a vector containing the time at which the follow-up
 #' is ended, or 2) a character string indicating the column name in \code{data}
@@ -77,8 +77,8 @@
 #' Censoring and truncation times are shifted by prec.factor*precision if event
 #' times and censoring/truncation times are equal.
 #' @param \dots Further arguments to be passed to or from other methods. They
-#' are ignored in this function. 
-#' 
+#' are ignored in this function.
+#'
 #' @return A data frame in long (counting process) format containing the
 #' covariates (replicated per subject). The following column names are used:
 #' \item{Tstart}{start dates of dataset} \item{Tstop}{stop dates of dataset}
@@ -87,31 +87,31 @@
 #' \item{weight.trunc}{weights due to truncation mechanism (if present)}
 #' \item{count}{row number within subject and event type under consideration}
 #' \item{failcode}{event type under consideration}
-#' 
+#'
 #' The first column is the subject identifier. If the argument "id" is missing,
 #' it has values 1:n and is named "id". Otherwise the information is taken from
 #' the \code{id} argument.
-#' 
+#'
 #' Variables as specified in \code{strata} and/or \code{keep} are included as
 #' well (see Details).
 #' @author Ronald Geskus
 #' @references Geskus RB (2011). Cause-Specific Cumulative Incidence Estimation
 #' and the Fine and Gray Model Under Both Left Truncation and Right Censoring.
 #' \emph{Biometrics} \bold{67}, 39--49.
-#' 
+#'
 #' Geskus, Ronald B. (2016). \emph{Data Analysis with Competing Risks and
 #' Intermediate States.} CRC Press, Boca Raton.
-#' 
+#'
 #' Putter H, Fiocco M, Geskus RB (2007). Tutorial in biostatistics: Competing
 #' risks and multi-state models. \emph{Statistics in Medicine} \bold{26},
 #' 2389--2430.
 #' @keywords datagen survival
 #' @examples
-#' 
+#'
 #' data(aidssi)
 #' aidssi.w <- crprep("time", "cause", data=aidssi, trans=c("AIDS","SI"),
 #'                    cens="event-free", id="patnr", keep="ccr5")
-#' 
+#'
 #' # calculate cause-specific cumulative incidence, no truncation,
 #' # compare with Cuminc (also from mstate)
 #' ci <- Cuminc(aidssi$time, aidssi$status)
@@ -123,14 +123,14 @@
 #'               weight=weight.cens, subset=failcode=="SI")
 #' plot(sf, fun="event", mark.time=FALSE)
 #' lines(CI.2~time,data=ci,type="s",col="red")
-#' 
+#'
 #' # Fine and Gray regression for cause 1
 #' cw <- coxph(Surv(Tstart,Tstop,status=="AIDS")~ccr5, data=aidssi.w,
 #'       weight=weight.cens, subset=failcode=="AIDS")
 #' cw
 #' # This can be checked with the results of crr (cmprsk)
 #' # crr(ftime=aidssi$time, fstatus=aidssi$status, cov1=as.numeric(aidssi$ccr5))
-#' 
+#'
 #' # Gray's log-rank test
 #' aidssi.wCCR <- crprep("time", "cause", data=aidssi, trans=c("AIDS","SI"),
 #'                       cens="event-free", id="patnr", strata="ccr5")
@@ -144,13 +144,13 @@
 #' # This can be compared with the results of cuminc (cmprsk)
 #' # with(aidssi, cuminc(time, status, group=ccr5)$Tests)
 #' # Note: results are not exactly the same
-#' 
+#'
 #' @export
 crprep.default <-
-function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata, 
+function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
          keep, shorten=TRUE, rm.na=TRUE, origin=0,
          prec.factor=1000, ...) {
-  
+
   # Coerce data to data.frame if given (from tibble/data.table)
   if (!missing(data)) data <- as.data.frame(data)
 
@@ -303,7 +303,7 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
         if(is.null(keep.name)) keep.name <- paste("V",1:nkeep,sep="")
       }
       if (nrow(keep) != nn)
-        stop("length Tstop and number of rows in keep are differents")
+        stop("length Tstop and number of rows in keep are different")
       if (nkeep == 1)
         keep <- keep[, 1]
     }
@@ -335,8 +335,8 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
     if(len.strat==1){ # no strata
       data.weight <- create.wData.omega(Tstart, Tstop, status, num.id, 1, failcode, cens)
       tmp.time <- data.weight$Tstop
-      data.weight$weight.cens[order(tmp.time)] <- summary(surv.cens, times=tmp.time-prec)$surv
-      if(calc.trunc) data.weight$weight.trunc[order(-tmp.time)] <- summary(surv.trunc, times=-tmp.time)$surv
+      data.weight$weight.cens <- summary(surv.cens, times=tmp.time-prec)$surv
+      if(calc.trunc) data.weight$weight.trunc] <- summary(surv.trunc, times=-tmp.time)$surv
     } else {
       data.weight <- vector("list",len.strat)
       if(is.na(strat[len.strat])) {
@@ -348,8 +348,8 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
         tmp.sel <- !is.na(strata.num) & strata.num==tmp.strat
         data.weight[[tmp.strat]] <- create.wData.omega(Tstart[tmp.sel], Tstop[tmp.sel], status[tmp.sel], num.id[tmp.sel], tmp.strat, failcode, cens)
         tmp.time <- data.weight[[tmp.strat]]$Tstop
-        data.weight[[tmp.strat]]$weight.cens[order(tmp.time)] <- summary(surv.cens[tmp.strat], times=tmp.time-prec)$surv
-        if(calc.trunc) data.weight[[tmp.strat]]$weight.trunc[order(-tmp.time)] <- summary(surv.trunc[tmp.strat], times=-tmp.time)$surv
+        data.weight[[tmp.strat]]$weight.cens <- summary(surv.cens[tmp.strat], times=tmp.time-prec)$surv
+        if(calc.trunc) data.weight[[tmp.strat]]$weight.trunc <- summary(surv.trunc[tmp.strat], times=-tmp.time)$surv
       }
       data.weight <- do.call("rbind", data.weight)
     }
@@ -488,5 +488,5 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
 }
 
 #' @inheritParams crprep.default
-#' @export 
+#' @export
 crprep <- function(Tstop, ...) UseMethod("crprep")

--- a/R/crprep.R
+++ b/R/crprep.R
@@ -338,7 +338,7 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
       data.weight <- create.wData.omega(Tstart, Tstop, status, num.id, 1, failcode, cens)
       tmp.time <- data.weight$Tstop
       data.weight$weight.cens <- summary(surv.cens, times=tmp.time)$surv
-      if(calc.trunc) data.weight$weight.trunc] <- summary(surv.trunc, times=-tmp.time)$surv
+      if(calc.trunc) data.weight$weight.trunc <- summary(surv.trunc, times=-tmp.time)$surv
     } else {
       data.weight <- vector("list",len.strat)
       if(is.na(strat[len.strat])) {

--- a/R/crprep.R
+++ b/R/crprep.R
@@ -334,13 +334,13 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
   len.strat <- length(strat)
   ## Start weight calculation per event type
   for(failcode in trans) {
+    data.weight <- create.wData.omega(Tstart, Tstop, status, num.id, strata.num, failcode, cens)
     if(len.strat==1){ # no strata
-      data.weight <- create.wData.omega(Tstart, Tstop, status, num.id, 1, failcode, cens)
       tmp.time <- data.weight$Tstop
       data.weight$weight.cens <- summary(surv.cens, times=tmp.time)$surv
       if(calc.trunc) data.weight$weight.trunc <- summary(surv.trunc, times=-tmp.time)$surv
     } else {
-      data.weight <- vector("list",len.strat)
+      data.weight <- split(data.weight,data.weight$strata)
       if(is.na(strat[len.strat])) {
         tmp.sel <- is.na(strata.num)
         data.weight[[len.strat]] <- data.frame(id=num.id[tmp.sel], Tstart=Tstart[tmp.sel], Tstop=Tstop[tmp.sel], status=status[tmp.sel], strata=NA,  weight.cens=NA)
@@ -348,7 +348,6 @@ function(Tstop, status, data, trans=1, cens=0, Tstart=0, id, strata,
       }
       for(tmp.strat in 1:(len.strat-is.na(strat[len.strat]))){
         tmp.sel <- !is.na(strata.num) & strata.num==tmp.strat
-        data.weight[[tmp.strat]] <- create.wData.omega(Tstart[tmp.sel], Tstop[tmp.sel], status[tmp.sel], num.id[tmp.sel], tmp.strat, failcode, cens)
         tmp.time <- data.weight[[tmp.strat]]$Tstop
         data.weight[[tmp.strat]]$weight.cens <- summary(surv.cens[tmp.strat], times=tmp.time)$surv
         if(calc.trunc) data.weight[[tmp.strat]]$weight.trunc <- summary(surv.trunc[tmp.strat], times=-tmp.time)$surv


### PR DESCRIPTION
The following changes have been made:
- Remove the reordering of the time points in the computation of the censoring and truncation weights using summary.survfit. From version 2.39-5 onwards summary.survfit no longer assumes that the times argument is sorted. (Pointed out by Grace Zhou)
- Set timefix=FALSE in summary.survfit. This is needed for the proper handling of ties, due to the introduction of timefix=TRUE in version 2.41-1.
- Correct a bug in the computation of stratum-specific weights. When stratum-specific weights were computed, weights only changed at times of the event of interest within the stratum. This works fine for the Aalen-Johansen estimator, but when using coxph for the proportional subdistribution hazards model, weights also need to be updated at times of the event of interest within other strata

**Note:**
The crprep function cannot be used in version 4.0 of R if truncation weights are computed. With the data set
```
tmp <-  as.data.frame(matrix(c(1,2,6,1,3,1,3,2,4,4,6,1,5,5,7,1),byrow=TRUE,nrow=4))
names(tmp) <- c("id","tstart","tstop","status")
```

In the past (I checked version 3.3-1, released on 2022-03-03), the summary.survfit function didn't handle negative survival times properly. At all time points before the first jump, the value of the survival function is set at the value at the first jump. Also, the time points were sorted (this change did not introduce a problem in my code).  The output should be (note that the first jump occurs at time -5):

 time n.risk n.event survival std.err lower 95% CI upper 95% CI
   -5      3       1    0.667   0.272        0.300            1
   -6      3       0    1.000   0.000        1.000            1
   -3      3       1    0.444   0.257        0.143            1
   -6      3       0    1.000   0.000        1.000            1
   -7      3       0    1.000   0.000        1.000            1
   -6      3       0    1.000   0.000        1.000            1
   -7      3       0    1.000   0.000        1.000            1
 
While it gave:

 time n.risk n.event censored survival std.err lower 95% CI upper 95% CI
   -7      3       0        0    0.667   0.272        0.300            1
   -7      3       0        0    0.667   0.272        0.300            1
   -6      3       0        0    0.667   0.272        0.300            1
   -6      3       0        0    0.667   0.272        0.300            1
   -6      3       0        0    0.667   0.272        0.300            1
   -5      3       1        0    0.667   0.272        0.300            1
   -3      3       1        0    0.444   0.257        0.143            1
  
 Indeed, if I add 10 to all time values, so that they become positive, then results are fine in the old version as well. I couldn’t find any reported change in the NEWS file of the survival package that explains the difference, so I don’t know when the correct version of summary.survfit was introduced.


